### PR TITLE
Refactor a2pcej library for clarity and robustness.

### DIFF
--- a/a2pcej/a2pcej.py
+++ b/a2pcej/a2pcej.py
@@ -19,7 +19,7 @@ class A2pcej:
         self.delimiter = delimiter if delimiter is not None else self.phonetic_dict['delimiter']
         self.sign = sign if sign is not None else self.phonetic_dict['sign']
 
-    def __converter__(self, letter):
+    def _converter(self, letter):
         if letter.upper() in self.phonetic_dict['alphabet'].keys():
             phonetic_code = self.phonetic_dict['alphabet'][letter.upper()]
             if letter.isupper():

--- a/a2pcej/a2pcej.py
+++ b/a2pcej/a2pcej.py
@@ -1,22 +1,25 @@
 # -*- coding: utf-8 -*-
 """ Convert Alphabet to Phonetic Code in English and Japanease."""
 from __future__ import absolute_import, unicode_literals
-from sys import version_info
 from .phonetics import Phonetics
 
 
 class A2pcej:
     """ A2pcej """
-    def __init__(self, lang=None, delimiter=None, sign=None, num=False):
-        self.lang = lang if lang else 'ja'
-        self.delimiter = delimiter if delimiter else '・'
-        self.sign = sign if sign else '（大文字）'
+    def __init__(self, lang='ja', delimiter=None, sign=None, num=False):
+        self.lang = lang
         self.num = num
         self.phonetics = Phonetics()
-        self.phonetic_dict = self.phonetics.get_phonetics(lang)
+        try:
+            # Ensure self.lang is used, not the potentially None 'lang' from init
+            self.phonetic_dict = self.phonetics.get_phonetics(self.lang) 
+        except KeyError:
+            raise ValueError(f"Language '{self.lang}' is not supported.")
 
-    def __converter(self, letter):
-        letter = letter.decode('utf-8') if version_info[0] == 2 else letter
+        self.delimiter = delimiter if delimiter is not None else self.phonetic_dict['delimiter']
+        self.sign = sign if sign is not None else self.phonetic_dict['sign']
+
+    def __converter__(self, letter):
         if letter.upper() in self.phonetic_dict['alphabet'].keys():
             phonetic_code = self.phonetic_dict['alphabet'][letter.upper()]
             if letter.isupper():

--- a/a2pcej/a2pcej.py
+++ b/a2pcej/a2pcej.py
@@ -19,7 +19,7 @@ class A2pcej:
         self.delimiter = delimiter if delimiter is not None else self.phonetic_dict['delimiter']
         self.sign = sign if sign is not None else self.phonetic_dict['sign']
 
-    def _converter(self, letter):
+    def __converter(self, letter):
         if letter.upper() in self.phonetic_dict['alphabet'].keys():
             phonetic_code = self.phonetic_dict['alphabet'][letter.upper()]
             if letter.isupper():

--- a/a2pcej/phonetics.py
+++ b/a2pcej/phonetics.py
@@ -91,18 +91,38 @@ class Phonetics:
         ],
     }
 
+    DEFAULTS = {
+        'en': {
+            'delimiter': '-',
+            'sign': '(CAPS)',
+        },
+        'ja': {
+            'delimiter': '・',
+            'sign': '（大文字）',
+        },
+    }
+
     def get_phonetics(self, lang):
         """ create phonetic code list for lang """
+        if lang not in self.DEFAULTS:
+            raise KeyError(f"Language '{lang}' not found in DEFAULTS.")
+        defaults = self.DEFAULTS[lang]
         phonetics = {
             'alphabet': self.get_alphabet_dict(lang),
             'number': self.get_number_dict(lang),
+            'delimiter': defaults['delimiter'],
+            'sign': defaults['sign'],
         }
         return phonetics
 
     def get_alphabet_dict(self, lang):
-        phonetics = self.ALPHABET.get(lang)
+        if lang not in self.ALPHABET:
+            raise KeyError(f"Language '{lang}' not found in ALPHABET.")
+        phonetics = self.ALPHABET[lang]
         return {chr(65 + k): v for k, v in enumerate(phonetics) if k < 26}
 
     def get_number_dict(self, lang):
-        phonetics = self.NUMBER.get(lang)
+        if lang not in self.NUMBER:
+            raise KeyError(f"Language '{lang}' not found in NUMBER.")
+        phonetics = self.NUMBER[lang]
         return {str(k): v for k, v in enumerate(phonetics) if k < 10}

--- a/tests/test_a2pcej.py
+++ b/tests/test_a2pcej.py
@@ -43,9 +43,6 @@ class TestA2pcejInit(unittest.TestCase):
 class TestCommands(unittest.TestCase):
     """ test commands """
 
-    # Existing tests for conv_al and conv_ak should remain here
-    # These tests indirectly cover the __converter__ method as well.
-
     def test_conv_al(self):
         """ test conv_al """
         vaild_values = [

--- a/tests/test_a2pcej.py
+++ b/tests/test_a2pcej.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import unittest
-import pytest  # Added for exception testing
 
 from a2pcej import conv_ak, conv_al
 from a2pcej.a2pcej import A2pcej  # Import A2pcej

--- a/tests/test_a2pcej.py
+++ b/tests/test_a2pcej.py
@@ -35,9 +35,9 @@ class TestA2pcejInit(unittest.TestCase):
 
     def test_init_unsupported_language(self):
         """Test A2pcej instantiation raises ValueError for unsupported language."""
-        with pytest.raises(ValueError) as excinfo:
+        with self.assertRaises(ValueError) as excinfo:
             A2pcej(lang='fr')
-        self.assertIn("Language 'fr' is not supported.", str(excinfo.value))
+        self.assertIn("Language 'fr' is not supported.", str(excinfo.exception))
 
 
 class TestCommands(unittest.TestCase):

--- a/tests/test_a2pcej.py
+++ b/tests/test_a2pcej.py
@@ -1,12 +1,51 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import unittest
+import pytest  # Added for exception testing
 
 from a2pcej import conv_ak, conv_al
+from a2pcej.a2pcej import A2pcej  # Import A2pcej
+
+
+class TestA2pcejInit(unittest.TestCase):
+    """Test A2pcej.__init__ method"""
+
+    def test_init_default_delimiter_sign(self):
+        """Test that delimiter and sign are set from language defaults if not provided."""
+        # Test with 'ja' (default lang)
+        a2pcej_ja = A2pcej()
+        self.assertEqual(a2pcej_ja.lang, 'ja')
+        self.assertEqual(a2pcej_ja.delimiter, '・')
+        self.assertEqual(a2pcej_ja.sign, '（大文字）')
+
+        # Test with 'en'
+        a2pcej_en = A2pcej(lang='en')
+        self.assertEqual(a2pcej_en.lang, 'en')
+        self.assertEqual(a2pcej_en.delimiter, '-')
+        self.assertEqual(a2pcej_en.sign, '(CAPS)')
+
+    def test_init_override_delimiter_sign(self):
+        """Test that provided delimiter and sign override language defaults."""
+        a2pcej_custom_ja = A2pcej(lang='ja', delimiter='/', sign='(大)')
+        self.assertEqual(a2pcej_custom_ja.delimiter, '/')
+        self.assertEqual(a2pcej_custom_ja.sign, '(大)')
+
+        a2pcej_custom_en = A2pcej(lang='en', delimiter='--', sign='[CAPS]')
+        self.assertEqual(a2pcej_custom_en.delimiter, '--')
+        self.assertEqual(a2pcej_custom_en.sign, '[CAPS]')
+
+    def test_init_unsupported_language(self):
+        """Test A2pcej instantiation raises ValueError for unsupported language."""
+        with pytest.raises(ValueError) as excinfo:
+            A2pcej(lang='fr')
+        self.assertIn("Language 'fr' is not supported.", str(excinfo.value))
 
 
 class TestCommands(unittest.TestCase):
     """ test commands """
+
+    # Existing tests for conv_al and conv_ak should remain here
+    # These tests indirectly cover the __converter__ method as well.
 
     def test_conv_al(self):
         """ test conv_al """

--- a/tests/test_phonetics.py
+++ b/tests/test_phonetics.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import unittest
-import pytest  # Added for exception testing
-
 from a2pcej.phonetics import Phonetics
 
 

--- a/tests/test_phonetics.py
+++ b/tests/test_phonetics.py
@@ -40,18 +40,18 @@ class TestPhonetics(unittest.TestCase):  # unittest.TestCase can be kept or chan
 
     def test_get_phonetics_unsupported_language(self):
         """ Test get_phonetics raises KeyError for unsupported language """
-        with pytest.raises(KeyError) as excinfo:
+        with self.assertRaises(KeyError) as excinfo:
             self.phonetics.get_phonetics('fr')
-        self.assertIn("'fr' not found in DEFAULTS", str(excinfo.value))
+        self.assertIn("'fr' not found in DEFAULTS", str(excinfo.exception))
 
     def test_get_alphabet_dict_unsupported_language(self):
         """ Test get_alphabet_dict raises KeyError for unsupported language """
-        with pytest.raises(KeyError) as excinfo:
+        with self.assertRaises(KeyError) as excinfo:
             self.phonetics.get_alphabet_dict('fr')
-        self.assertIn("'fr' not found in ALPHABET", str(excinfo.value))
+        self.assertIn("'fr' not found in ALPHABET", str(excinfo.exception))
 
     def test_get_number_dict_unsupported_language(self):
         """ Test get_number_dict raises KeyError for unsupported language """
-        with pytest.raises(KeyError) as excinfo:
+        with self.assertRaises(KeyError) as excinfo:
             self.phonetics.get_number_dict('fr')
-        self.assertIn("'fr' not found in NUMBER", str(excinfo.value))
+        self.assertIn("'fr' not found in NUMBER", str(excinfo.exception))

--- a/tests/test_phonetics.py
+++ b/tests/test_phonetics.py
@@ -1,20 +1,59 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import unittest
+import pytest  # Added for exception testing
 
 from a2pcej.phonetics import Phonetics
 
 
-class TestPhonetics(unittest.TestCase):
+class TestPhonetics(unittest.TestCase):  # unittest.TestCase can be kept or changed to object
     """ test class of phonetics.py """
 
-    def test_phonetics(self):
-        """ test method for phonetics """
+    def setUp(self):
+        """Setup method to create a Phonetics instance"""
+        self.phonetics = Phonetics()
+
+    def test_get_phonetics_basic_structure(self):
+        """ Test that get_phonetics returns dicts with expected keys for supported languages """
         langs = ['en', 'ja']
         for lang in langs:
-            alphabet_dict = Phonetics().get_phonetics(lang)['alphabet']
-            number_dict = Phonetics().get_phonetics(lang)['number']
+            phonetic_info = self.phonetics.get_phonetics(lang)
+            self.assertIn('alphabet', phonetic_info)
+            self.assertIn('number', phonetic_info)
+            self.assertIn('delimiter', phonetic_info)
+            self.assertIn('sign', phonetic_info)
+
+            alphabet_dict = phonetic_info['alphabet']
+            number_dict = phonetic_info['number']
             self.assertTrue('A' in alphabet_dict.keys())
-            self.assertTrue('Z' in  alphabet_dict.keys())
+            self.assertTrue('Z' in alphabet_dict.keys())
             self.assertTrue('0' in number_dict.keys())
-            self.assertTrue('9' in  number_dict.keys())
+            self.assertTrue('9' in number_dict.keys())
+
+    def test_get_phonetics_default_values(self):
+        """ Test get_phonetics returns correct default delimiter and sign """
+        en_phonetics = self.phonetics.get_phonetics('en')
+        self.assertEqual(en_phonetics['delimiter'], '-')
+        self.assertEqual(en_phonetics['sign'], '(CAPS)')
+
+        ja_phonetics = self.phonetics.get_phonetics('ja')
+        self.assertEqual(ja_phonetics['delimiter'], '・')
+        self.assertEqual(ja_phonetics['sign'], '（大文字）')
+
+    def test_get_phonetics_unsupported_language(self):
+        """ Test get_phonetics raises KeyError for unsupported language """
+        with pytest.raises(KeyError) as excinfo:
+            self.phonetics.get_phonetics('fr')
+        self.assertIn("'fr' not found in DEFAULTS", str(excinfo.value))
+
+    def test_get_alphabet_dict_unsupported_language(self):
+        """ Test get_alphabet_dict raises KeyError for unsupported language """
+        with pytest.raises(KeyError) as excinfo:
+            self.phonetics.get_alphabet_dict('fr')
+        self.assertIn("'fr' not found in ALPHABET", str(excinfo.value))
+
+    def test_get_number_dict_unsupported_language(self):
+        """ Test get_number_dict raises KeyError for unsupported language """
+        with pytest.raises(KeyError) as excinfo:
+            self.phonetics.get_number_dict('fr')
+        self.assertIn("'fr' not found in NUMBER", str(excinfo.value))


### PR DESCRIPTION
This commit introduces several refactoring improvements to the a2pcej library:

1.  **Phonetics Class (`a2pcej/phonetics.py`):**
    *   Added a `DEFAULTS` dictionary to store default delimiters and capitalization signs for each supported language ('en', 'ja').
    *   `get_phonetics` now includes these defaults in its output.
    *   Improved error handling: `get_phonetics`, `get_alphabet_dict`, and `get_number_dict` now raise a `KeyError` if an unsupported language is requested.

2.  **A2pcej Class (`a2pcej/a2pcej.py`):**
    *   `__init__` now fetches default delimiters and signs from the `Phonetics` class if not explicitly provided, making them language-aware.
    *   Corrected an issue where `self.phonetic_dict` was populated using the `lang` parameter directly instead of `self.lang`.
    *   Removed Python 2 compatibility code (UTF-8 decoding) from the `__converter__` method.
    *   Added error handling: Instantiating `A2pcej` with an unsupported language now raises a `ValueError` with a user-friendly message.

3.  **Tests (`tests/test_a2pcej.py`, `tests/test_phonetics.py`):**
    *   Updated existing tests and added new ones to verify the changes.
    *   New tests cover the correct retrieval of default delimiters/signs, overriding of these defaults, and the new error handling for unsupported languages.

These changes make the library more robust, easier to understand, and simpler to maintain by centralizing language-specific defaults and improving error reporting.